### PR TITLE
Add calibration option to fuzzy_where

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### master
 * Travis, coveralls and code climate integrations
+* Add calibration option to `fuzzy_where`
 
 ### 0.5.0 - 2015-07-05
 

--- a/lib/fuzzy_where/config.rb
+++ b/lib/fuzzy_where/config.rb
@@ -29,6 +29,9 @@ module FuzzyWhere
     # @!attribute [rw] membership_degree_column_name
     #   @return [String] membership degree column name definition
     config_accessor :membership_degree_column_name
+    # @!attribute [rw] calibration_name
+    #   @return [String] calibration condition name definition
+    config_accessor :calibration_name
     # @!attribute [rw] predicates_file
     #   configuration file location
     config_accessor :predicates_file
@@ -50,11 +53,11 @@ module FuzzyWhere
       fail ConfigError, 'The configuration file is not defined.' unless path
       file = path.is_a?(Pathname) ? path : Pathname.new(path)
       if !file.exist?
-        fail ConfigError, "The configuration file #{@path} was not found."
+        fail ConfigError, "The configuration file #{path} was not found."
       elsif !file.file?
-        fail ConfigError, "The configuration file #{@path} is not a file."
+        fail ConfigError, "The configuration file #{path} is not a file."
       elsif !file.readable?
-        fail ConfigError, "The configuration file #{@path} is not readable."
+        fail ConfigError, "The configuration file #{path} is not readable."
       end
       HashWithIndifferentAccess.new(YAML.load_file(file))
     end
@@ -63,5 +66,6 @@ module FuzzyWhere
   configure do |config|
     config.where_method_name = :fuzzy_where
     config.membership_degree_column_name = :membership_degree
+    config.calibration_name = :calibration
   end
 end

--- a/lib/fuzzy_where/predicate_membership_degree.rb
+++ b/lib/fuzzy_where/predicate_membership_degree.rb
@@ -17,8 +17,8 @@ module FuzzyWhere
       @fuzzy_predicate = fuzzy_predicate
     end
 
-    # Take instance attributtes and return a calculations for them
-    # Based on fuzzzy set trapezium function
+    # Take instance attributes and return a calculations for them
+    # Based on fuzzy set trapezium function
     # @return [String] the calculation query to be used for the column
     def membership_function
       min = @fuzzy_predicate[:min]
@@ -43,7 +43,7 @@ module FuzzyWhere
       "(#{right_border_formula}) ELSE 0 END"
     end
 
-    # Incresing function calculation
+    # Increasing function calculation
     # @return [String] condition representation for membership calculation
     def increasing
       "CASE WHEN #{greater_than(:core1, true)} THEN 1.0 "\

--- a/lib/generators/fuzzy_where/config_generator.rb
+++ b/lib/generators/fuzzy_where/config_generator.rb
@@ -7,7 +7,7 @@ module FuzzyWhere
 
       desc <<DESC
 Description:
-    Copies FuzzyWhere configuration file to your application's initializer directory.
+    Copies FuzzyWhere configuration files to your application's initializer directory.
 DESC
       # Create FuzzyWhere config file
       def copy_config_file

--- a/lib/generators/fuzzy_where/predicate_generator.rb
+++ b/lib/generators/fuzzy_where/predicate_generator.rb
@@ -12,7 +12,8 @@ DESC
       # Add Fuzzy predicate
       def add_fuzzy_predicate
         return if attributes.empty?
-        append_to_file 'config/fuzzy_predicates.yml', predicate_content(name, attributes)
+        append_to_file 'config/fuzzy_predicates.yml',
+                       predicate_content(name, attributes)
       end
 
       private

--- a/spec/fuzzy_where/config_spec.rb
+++ b/spec/fuzzy_where/config_spec.rb
@@ -22,6 +22,25 @@ describe FuzzyWhere::Configuration do
     end
   end
 
+  describe 'calibration_name' do
+    context 'by default' do
+      it 'should be calibration' do
+        expect(config.calibration_name).to eq :calibration
+      end
+    end
+    context 'configured via config block' do
+      before do
+        FuzzyWhere.configure { |c| c.calibration_name = :test }
+      end
+      it 'should be test' do
+        expect(config.calibration_name).to eq :test
+      end
+      after do
+        FuzzyWhere.configure { |c| c.calibration_name = :calibration }
+      end
+    end
+  end
+
   describe 'predicates_file' do
     context 'by default' do
       it 'should be nil' do

--- a/spec/fuzzy_where/predicate_membership_degree_spec.rb
+++ b/spec/fuzzy_where/predicate_membership_degree_spec.rb
@@ -10,9 +10,9 @@ describe FuzzyWhere::PredicateMembershipDegree do
       #   core2: 10
       #   max: 14
       let!(:kid) { { min: 'infinite', core1: 'infinite', core2: 10, max: 14 } }
-      it 'should be decreacing function' do
+      it 'should be decreasing function' do
         membership = FuzzyWhere::PredicateMembershipDegree.new('people', 'age', kid)
-        expect(membership.membership_function).to be_decreacing_function('people', 'age', kid)
+        expect(membership.membership_function).to be_decreasing_function('people', 'age', kid)
       end
     end
     context 'increasing function' do
@@ -22,9 +22,9 @@ describe FuzzyWhere::PredicateMembershipDegree do
       #   core2: infinite
       #   max: infinite
       let!(:old) { { min: 48, core1: 55, core2: 'infinite', max: 'infinite' } }
-      it 'should be increacing function' do
+      it 'should be increasing function' do
         membership = FuzzyWhere::PredicateMembershipDegree.new('people', 'age', old)
-        expect(membership.membership_function).to be_increacing_function('people', 'age', old)
+        expect(membership.membership_function).to be_increasing_function('people', 'age', old)
       end
     end
     context 'unimodal function' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+
 SimpleCov.start do
   add_filter 'spec/support'
 end

--- a/spec/support/membership_degree_function_matcher.rb
+++ b/spec/support/membership_degree_function_matcher.rb
@@ -27,7 +27,7 @@ module MembershipComparator
   end
 end
 
-RSpec::Matchers.define :be_decreacing_function do |table, column, predicate|
+RSpec::Matchers.define :be_decreasing_function do |table, column, predicate|
   include MembershipComparator
   match do |result|
     @table = table
@@ -48,13 +48,12 @@ RSpec::Matchers.define :be_decreacing_function do |table, column, predicate|
   end
 end
 
-RSpec::Matchers.define :be_increacing_function do |table, column, predicate|
+RSpec::Matchers.define :be_increasing_function do |table, column, predicate|
   include MembershipComparator
   match do |result|
     @table = table
     @column = column
     @predicate = predicate
-    puts "predicate=#{predicate}"
     result == increasing
   end
 
@@ -76,7 +75,6 @@ RSpec::Matchers.define :be_unimodal_function do |table, column, predicate|
     @table = table
     @column = column
     @predicate = predicate
-    puts "predicate=#{predicate}"
     result == unimodal
   end
 


### PR DESCRIPTION
Before you would get all rows within fuzzy condition, now you can tune
even more your fuzzy condition and select how flexible you want to be.

``` ruby
Hotel.fuzzy_where(price: :cheap, distance: :close, calibration: 0.5)
```

Will only fetch rows with a membership degree equal or greater to 0.5

This closes #8 
